### PR TITLE
Fix BORDL crashing if scale CV is negative during a gate with pattern >= 1

### DIFF
--- a/Bidoo/src/BORDL.cpp
+++ b/Bidoo/src/BORDL.cpp
@@ -904,9 +904,11 @@ void BORDL::process(const ProcessArgs &args) {
 	}
 
 	if (gateOn) {
+		auto clamped_scale = std::clamp(patterns[playedPattern].scale + inputs[SCALE_INPUT].getVoltage(), 0.f, (float)quantizer::numScales);
+
 		pitch = std::get<0>(quant.closestVoltageInScale(clamp(patterns[playedPattern].CurrentStep().pitch + rndPitch,-4.0f,6.0f) * clamp(patterns[playedPattern].sensitivity
 			+ (inputs[SENSITIVITY_INPUT].isConnected() ? rescale(inputs[SENSITIVITY_INPUT].getVoltage(),0.f,10.f,0.1f,1.0f) : 0.0f),0.1f,1.0f) + inputs[TRANSPOSE_INPUT].getVoltage(),
-			clamp(patterns[playedPattern].rootNote + rescale(clamp(inputs[ROOT_NOTE_INPUT].getVoltage(), 0.0f,10.0f),0.0f,10.0f,0.0f,11.0f), 0.0f, 11.0f), patterns[playedPattern].scale + inputs[SCALE_INPUT].getVoltage()));
+			clamp(patterns[playedPattern].rootNote + rescale(clamp(inputs[ROOT_NOTE_INPUT].getVoltage(), 0.0f,10.0f),0.0f,10.0f,0.0f,11.0f), 0.0f, 11.0f), clamped_scale));
 	}
 
 	if (patterns[playedPattern].CurrentStep().slide) {


### PR DESCRIPTION
Crashes in VCV Rack also.
To reproduce:
- Turn Pattern knob up to 1 or more
- Feed negative voltage into the Scale CV jack
- Make sure the sequencer is running

VCV Rack will crash immediately.

The reason is that the scale CV is not clamped in any way, but it's used to index the scales[] and map[] arrays. So a negative CV results in a negative array index.